### PR TITLE
fix: removed files should update the thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.1](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.0.0...v1.0.1) (2022-03-10)
+
+### Bug Fixes
+
+- removed files should update the thresholds ([26752eb](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/26752ebb514cf7be5fd0ab8a6fe130faccba4181)), closes [#2](https://github.com/ProductPlan/eslint-formatter-ratchet/issues/2)
+
 ## 1.0.0 (2022-03-08)
 
 ### Features

--- a/index.js
+++ b/index.js
@@ -142,7 +142,16 @@ const detectAndLogChanges = (
   Object.entries({ added, updated, deleted }).forEach(([setKey, set]) => {
     Object.entries(set).forEach(([fileKey, fileValue]) => {
       // Only check against files that were linted in the latest run.
-      if (!filesLinted.includes(fileKey)) return;
+      const fileLinted = filesLinted.includes(fileKey);
+      if (!fileLinted) {
+        // Check to see if the file wasn't linted because it no longer exists
+        // If it does exist then it wasn't a part of the latest run, like when running against staged files,
+        // and its previous results are safe to ignored.
+        // If it doesn't exist then any error counts associated with it should be removed and are accounted
+        // for later on.
+        const exists = fs.existsSync(fileKey);
+        if (exists) return;
+      }
 
       logger.group(chalk.white.underline(fileKey));
       let previousFileResults = previousResults[fileKey];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-formatter-ratchet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "repository": "https://github.com/ProductPlan/eslint-formatter-ratchet.git",
   "description": "Ratcheting applied to ESLint results so new issues don't creep in.",


### PR DESCRIPTION
### SUMMARY:
Files that were previously reporting issues but have since been removed should also have their issues removed from the threshold. In this case, a simple check for where or not a file that wasn't linted exists is enough.

Fixes: Deleted file results are not being properly cleaned up #2

### TESTING NOTES:
"The first principle is that you must not fool yourself, and you are the easiest person to fool."
- Fill in notes about your test approach -- discussion points:
  - [X] Unit tests
