### PR TITLE
fix: use relative paths in eslint-ratchet file

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const emoji = require("node-emoji");
 const warning = emoji.get("warning");
 const fire = emoji.get("fire");
 const cwd = process.cwd();
+const path = require('path');
 
 module.exports = function (results, context, logger = console) {
   const filesLinted = [];
@@ -28,7 +29,7 @@ module.exports = function (results, context, logger = console) {
   //   }
   // }
   results.forEach(({ messages, filePath, errorCount, warningCount }) => {
-    const file = filePath.replace(`${cwd}/`, "");
+    const file = path.relative(cwd, filePath);
     filesLinted.push(file);
     if (errorCount > 0 || warningCount > 0) {
       latestIssues[file] = {};


### PR DESCRIPTION
previous method was replacing the cwd with '' which fails in some scenarios.  Now uses path.relative

### SUMMARY:

- uses path.relative so that json files have relative paths

### SCREENSHOTS OR IT DIDN'T HAPPEN:

Before
![image](https://user-images.githubusercontent.com/29103243/158836160-39ea5eb8-282e-4579-9729-cbcf2d05f090.png)

After
![image](https://user-images.githubusercontent.com/29103243/158836066-d468702e-6e06-4c52-9767-0c5444bba7cb.png)

