### PR TITLE
Feat/support exit code bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.2.0](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.1.0...v1.2.0) (2023-08-21)
+
+### Features
+
+- add support for bypassing eslint erroring on rule violations ([f30e08c](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/f30e08cac2afc1929a9af2e0a5a8f8b5e915932c))
+
+### Bug Fixes
+
+- use the `logger` instead of `console` ([5647a52](https://github.com/ProductPlan/eslint-formatter-ratchet/commit/5647a52fedd922a4d7e70f9c5d61dbde12858698))
+
 ## [1.1.0](https://github.com/ProductPlan/eslint-formatter-ratchet/compare/v1.0.4...v1.1.0) (2023-01-06)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ In this case, we have two violations in the same file. When either of these impr
 
 In cases where ratcheting is already in place but we want to add new linting rules, or even adjust existing settings, it is expected that the ratcheting process will throw an error.
 
-In any situation where new changes are detected that violate the threshold, an error is thrown and details about which issues got worse are included. Since we expect new violations to occur though we follow the details in the message - copy the contents of `eslint-ratchet-latest.json` and use them to replace `eslint-ratchet.json` and check the changes in.
+In any situation where new changes are detected that violate the threshold, an error is thrown and details about which issues got worse are included. Since we expect new violations to occur though we can follow the details in the message - copy the contents of `eslint-ratchet-temp.json`, use them to replace `eslint-ratchet.json`, and check the changes in.
 
 # Tips
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - Updates the threshold when it improves
 - Stylized messages about result changes
 - Command-click a filename header to reveal it in your editor. _(if your terminal supports it)_
+- Allows for bypassing normal eslint erroring on rule violations
 
 ## TL;DR
 
@@ -52,6 +53,20 @@ Two files are created while processing results:
 
 - `eslint-ratchet.json` = used as the threshold and should be checked in
 - `eslint-ratchet-temp.json` = used to store the latest results before comparison and should be added to your `.gitignore`
+
+---
+
+### ENV options
+
+The following options can be provided via environment variables and change the behavior of the formatter.
+
+#### RATCHET_DEFAULT_EXIT_ZERO
+
+Default: `null | undefined`
+
+When set to `true` calls `process.exit(0)` while ratcheting results regardless of rule violations. This is particularly useful if you want to ratchet a codebase where there are violations that would otherwise cause eslint to throw and want instead to rely on the ratcheting counts.
+
+> Note: this will not prevent the formatter itself from throwing when **new** issues are detected.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Default: `null | undefined`
 
 When set to `true` calls `process.exit(0)` while ratcheting results regardless of rule violations. This is particularly useful if you want to ratchet a codebase where there are violations that would otherwise cause eslint to throw and want instead to rely on the ratcheting counts.
 
+Example: `RATCHET_DEFAULT_EXIT_ZERO=true yarn eslint -f ratchet`
+
 > Note: this will not prevent the formatter itself from throwing when **new** issues are detected.
 
 ---

--- a/index.js
+++ b/index.js
@@ -50,9 +50,9 @@ module.exports = function (results, context, logger = console) {
   if (logResults) {
     // Use the default table formatter to post the results
     // Since Eslint expects to only be dealing with a single formatter we can wind up in a case where an error is thrown due to
-    // a violation but thhis formatter is only concerned with ratcheting and effectively eats the details. To prevent this from
-    // happening we'll now log results via the table formaatter so that issues are always exposed.
-    console.log(tableFormatter(results));
+    // a violation but this formatter is only concerned with ratcheting and effectively eats the details. To prevent this from
+    // happening we'll now log results via the table formatter so that issues are always exposed.
+    logger.log(tableFormatter(results));
   }
 
   // Store these latest results up front.
@@ -60,7 +60,7 @@ module.exports = function (results, context, logger = console) {
   // when those increases were expected.
   fs.writeFileSync(
     "./eslint-ratchet-temp.json",
-    JSON.stringify({ ...previousIssues, ...latestIssues }, null, 4)
+    JSON.stringify({ ...previousIssues, ...latestIssues }, null, 4),
   );
 
   // Perform a basic check to see if anything has changed
@@ -71,20 +71,20 @@ module.exports = function (results, context, logger = console) {
   // Since the latest issues will have a diff of `undefined` all we need to do is
   // filter the results to those that aren't null/undefined
   const addsMatchingLintedFiles = Object.entries(added).filter(([k, v]) =>
-    filesLinted.includes(k)
+    filesLinted.includes(k),
   );
   const updatesMatchingLintedFiles = Object.entries(updated).filter(([k, v]) =>
-    filesLinted.includes(k)
+    filesLinted.includes(k),
   );
   const deletesMatchingLintedFiles = Object.entries(deleted).filter(([k, v]) =>
-    filesLinted.includes(k)
+    filesLinted.includes(k),
   );
 
   // Also look for files that were previously linted but no longer exist.
   // This helps account for times when linting may only be performed against a subset of files
   // but one or more of the previous files has been removed.
   const missingFiles = Object.keys(previousIssues).filter(
-    (filepath) => !fs.existsSync(filepath)
+    (filepath) => !fs.existsSync(filepath),
   );
 
   const hasChanged =
@@ -98,8 +98,8 @@ module.exports = function (results, context, logger = console) {
     logger.group(
       chalk.yellow(
         warning,
-        ` eslint-ratchet: Changes to eslint results detected!!!`
-      )
+        ` eslint-ratchet: Changes to eslint results detected!!!`,
+      ),
     );
 
     // Loop over the changes to determine and log what's different
@@ -109,37 +109,37 @@ module.exports = function (results, context, logger = console) {
       added,
       updated,
       deleted,
-      logger
+      logger,
     );
 
     // If we find any "issues" (increased/new counts) throw a warning and fail the ratcheting check
     if (newIssues > 0) {
       logger.log(
         fire,
-        chalk.red(` New eslint-ratchet issues have been detected!!!`)
+        chalk.red(` New eslint-ratchet issues have been detected!!!`),
       );
       logger.log(
         `These latest eslint results have been saved to ${chalk.yellow.underline(
-          "eslint-ratchet-temp.json"
+          "eslint-ratchet-temp.json",
         )}. \nIf these results were expected then use them to replace the content of ${chalk.white.underline(
-          "eslint-ratchet.json"
-        )} and check it in.`
+          "eslint-ratchet.json",
+        )} and check it in.`,
       );
       throw new Error("View output above for more details");
     } else {
       // Otherwise update the ratchet tracking and log a message about it
       fs.writeFileSync(
         "./eslint-ratchet.json",
-        JSON.stringify(updatedResults, null, 4)
+        JSON.stringify(updatedResults, null, 4),
       );
       fs.writeFileSync(
         "./eslint-ratchet-temp.json",
-        JSON.stringify({}, null, 4)
+        JSON.stringify({}, null, 4),
       );
       return chalk.green(
         `Changes found are all improvements! These new results have been saved to ${chalk.white.underline(
-          "eslint-ratchet.json"
-        )}`
+          "eslint-ratchet.json",
+        )}`,
       );
     }
   }
@@ -153,8 +153,8 @@ module.exports = function (results, context, logger = console) {
 const logColorfulValue = (violationType, value, previously, color, logger) => {
   logger.log(
     `--> ${violationType}: ${chalk[color](value)} (previously: ${chalk.yellow(
-      previously
-    )})`
+      previously,
+    )})`,
   );
 };
 
@@ -166,7 +166,7 @@ const detectAndLogChanges = (
   added,
   updated,
   deleted,
-  logger
+  logger,
 ) => {
   // Keep track of any new issues - where the counts for a previously reported
   // issue have gone up
@@ -233,7 +233,7 @@ const detectAndLogChanges = (
                 value,
                 previousValue,
                 "red",
-                logger
+                logger,
               );
             } else if (value < previousValue) {
               logColorfulValue(
@@ -241,7 +241,7 @@ const detectAndLogChanges = (
                 value,
                 previousValue,
                 "green",
-                logger
+                logger,
               );
             }
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const path = require("path");
 const tableFormatter = require("eslint-formatter-table");
 
 module.exports = function (results, context, logger = console) {
+  const defaultExitZero = process.env.RATCHET_DEFAULT_EXIT_ZERO === "true";
   const filesLinted = [];
   const latestIssues = {};
 
@@ -142,6 +143,15 @@ module.exports = function (results, context, logger = console) {
         )}`,
       );
     }
+  }
+
+  // If there is any rule violation of type "error", eslint will exit non-zero.
+  // Since we're ratcheting though chances are we already have errors - we just don't want new ones.
+  // To get around eslint's default behavior but also not stray too far from it we'll check an env var to
+  // determine if we should bypass that behavior and instead exit will 0.
+  if (defaultExitZero) {
+    logger.log("eslint-ratchet: causing process to exit 0");
+    process.exit(0);
   }
 
   // Because eslint expects a string response from formatters, but our messaging is already complete, just

--- a/index.test.js
+++ b/index.test.js
@@ -54,7 +54,7 @@ describe("eslint-ratchet", () => {
 
     setupMocks();
     expect(() => formatter(newResults, null, logger)).to.throw();
-    expect(JSON.stringify(messages)).to.equal(JSON.stringify(expectedMessages));
+    expectedMessages.forEach((message) => expect(messages).to.contain(message));
 
     const newValues = JSON.parse(fs.readFileSync("./eslint-ratchet-temp.json"));
     expect(JSON.stringify(newValues)).to.equal(JSON.stringify(expectedLatest));
@@ -79,7 +79,7 @@ describe("eslint-ratchet", () => {
 
     setupMocks();
     formatter(newResults, null, logger);
-    expect(JSON.stringify(messages)).to.equal(JSON.stringify(expectedMessages));
+    expectedMessages.forEach((message) => expect(messages).to.contain(message));
 
     const newValues = JSON.parse(fs.readFileSync("./eslint-ratchet.json"));
     expect(JSON.stringify(newValues)).to.equal(JSON.stringify(expectedLatest));
@@ -105,7 +105,7 @@ describe("eslint-ratchet", () => {
       [`${newResults[1].filePath}`]: "",
     });
     formatter(newResults, null, logger);
-    expect(JSON.stringify(messages)).to.equal(JSON.stringify(expectedMessages));
+    expectedMessages.forEach((message) => expect(messages).to.contain(message));
 
     const newValues = JSON.parse(fs.readFileSync("./eslint-ratchet.json"));
     expect(JSON.stringify(newValues)).to.equal(JSON.stringify(expectedLatest));
@@ -121,7 +121,7 @@ describe("eslint-ratchet", () => {
 
     setupMocks({ "some/path/file-a.jsx": "" });
     formatter(newResults, null, logger);
-    expect(JSON.stringify(messages)).to.equal(JSON.stringify(expectedMessages));
+    expectedMessages.forEach((message) => expect(messages).to.contain(message));
 
     const newValues = JSON.parse(fs.readFileSync("./eslint-ratchet.json"));
     expect(JSON.stringify(newValues)).to.equal(JSON.stringify(expectedLatest));
@@ -145,7 +145,7 @@ describe("eslint-ratchet", () => {
     setupMocks();
     fs.unlinkSync("./eslint-ratchet.json");
     expect(() => formatter(newResults, null, logger)).to.throw();
-    expect(JSON.stringify(messages)).to.equal(JSON.stringify(expectedMessages));
+    expectedMessages.forEach((message) => expect(messages).to.contain(message));
     restoreMocks();
   });
 
@@ -180,7 +180,7 @@ describe("eslint-ratchet", () => {
       }),
     });
     formatter(newResults, null, logger);
-    expect(JSON.stringify(messages)).to.equal(JSON.stringify(expectedMessages));
+    expectedMessages.forEach((message) => expect(messages).to.contain(message));
 
     restoreMocks();
   });

--- a/index.test.js
+++ b/index.test.js
@@ -3,6 +3,7 @@ const chai = require("chai");
 const expect = chai.expect;
 const mock = require("mock-fs");
 const formatter = require("./index");
+const sinon = require("sinon");
 
 let messages = [];
 const logger = {
@@ -12,6 +13,10 @@ const logger = {
 };
 
 describe("eslint-ratchet", () => {
+  beforeEach(function () {
+    messages = [];
+  });
+
   it("doesn't throw errors or log messages when there are no changes", () => {
     setupMocks();
     formatter(getMockResults(), null, logger);
@@ -106,7 +111,6 @@ describe("eslint-ratchet", () => {
     });
     formatter(newResults, null, logger);
     expectedMessages.forEach((message) => expect(messages).to.contain(message));
-
     const newValues = JSON.parse(fs.readFileSync("./eslint-ratchet.json"));
     expect(JSON.stringify(newValues)).to.equal(JSON.stringify(expectedLatest));
     restoreMocks();
@@ -122,7 +126,6 @@ describe("eslint-ratchet", () => {
     setupMocks({ "some/path/file-a.jsx": "" });
     formatter(newResults, null, logger);
     expectedMessages.forEach((message) => expect(messages).to.contain(message));
-
     const newValues = JSON.parse(fs.readFileSync("./eslint-ratchet.json"));
     expect(JSON.stringify(newValues)).to.equal(JSON.stringify(expectedLatest));
     restoreMocks();
@@ -181,8 +184,81 @@ describe("eslint-ratchet", () => {
     });
     formatter(newResults, null, logger);
     expectedMessages.forEach((message) => expect(messages).to.contain(message));
-
     restoreMocks();
+  });
+
+  describe("option: RATCHET_DEFAULT_EXIT_ZERO", () => {
+    it("disabled: does not log", () => {
+      setupMocks({ "some/path/file-a.jsx": "", "another/path/file-b.js": "" });
+      formatter(getMockResults(), null, logger);
+      expect(messages).to.not.contain(
+        "eslint-ratchet: causing process to exit 0",
+      );
+      restoreMocks();
+    });
+
+    it("enabled: logs and exits", () => {
+      process.env.RATCHET_DEFAULT_EXIT_ZERO = "true";
+      let exitCode = null;
+      sinon.stub(process, "exit").callsFake((event) => (exitCode = event));
+      setupMocks({ "some/path/file-a.jsx": "", "another/path/file-b.js": "" });
+      formatter(getMockResults(), null, logger);
+      expect(messages).to.contain("eslint-ratchet: causing process to exit 0");
+      expect(exitCode).to.equal(0);
+      process.exit.restore();
+      delete process.env.RATCHET_DEFAULT_EXIT_ZERO;
+      restoreMocks();
+    });
+
+    it("enabled: throws errors and logs messages when violations increase", () => {
+      process.env.RATCHET_DEFAULT_EXIT_ZERO = "true";
+      const newResults = getMockResults();
+      newResults[1].errorCount = 3;
+      newResults[1].messages.push({
+        ruleId: "react/jsx-no-target-blank",
+        severity: 2,
+        message:
+          'Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations',
+        messageId: "noTargetBlankWithoutNoreferrer",
+      });
+      const expectedLatest = {
+        "some/path/file-a.jsx": {
+          "react/jsx-no-target-blank": {
+            warning: 0,
+            error: 3,
+          },
+        },
+        "another/path/file-b.js": {
+          "@productplan/custom-rules/throw-or-log": {
+            warning: 2,
+            error: 0,
+          },
+        },
+      };
+      const expectedMessages = [
+        "⚠️  eslint-ratchet: Changes to eslint results detected!!!",
+        "some/path/file-a.jsx",
+        "react/jsx-no-target-blank",
+        "--> error: 3 (previously: 2)",
+        "🔥",
+        "These latest eslint results have been saved to eslint-ratchet-temp.json. \nIf these results were expected then use them to replace the content of eslint-ratchet.json and check it in.",
+      ];
+
+      setupMocks();
+      expect(() => formatter(newResults, null, logger, true)).to.throw();
+      expectedMessages.forEach((message) =>
+        expect(messages).to.contain(message),
+      );
+
+      const newValues = JSON.parse(
+        fs.readFileSync("./eslint-ratchet-temp.json"),
+      );
+      expect(JSON.stringify(newValues)).to.equal(
+        JSON.stringify(expectedLatest),
+      );
+      restoreMocks();
+      delete process.env.RATCHET_DEFAULT_EXIT_ZERO;
+    });
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mocha": "9.2.1",
     "mock-fs": "5.1.2",
     "nyc": "15.1.0",
+    "prettier": "3.0.2",
     "standard-version": "9.1.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mock-fs": "5.1.2",
     "nyc": "15.1.0",
     "prettier": "3.0.2",
+    "sinon": "15.2.0",
     "standard-version": "9.1.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-formatter-ratchet",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js",
   "repository": "https://github.com/ProductPlan/eslint-formatter-ratchet.git",
   "description": "Ratcheting applied to ESLint results so new issues don't creep in.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,6 +2415,11 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
+prettier@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.2.tgz#78fcecd6d870551aa5547437cdae39d4701dca5b"
+  integrity sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,6 +374,41 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@sinonjs/commons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
+  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^10.0.2", "@sinonjs/fake-timers@^10.3.0":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
+  integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+
+"@sinonjs/samsam@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.0.tgz#0d488c91efb3fa1442e26abea81759dfc8b5ac60"
+  integrity sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
+  integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
@@ -1082,6 +1117,11 @@ diff@5.0.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
+diff@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
+
 dot-prop@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
@@ -1643,6 +1683,11 @@ is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1780,6 +1825,11 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
+just-extend@^4.0.2:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
 kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
@@ -1874,6 +1924,11 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
@@ -2117,6 +2172,17 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+nise@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.4.tgz#491ce7e7307d4ec546f5a659b2efe94a18b4bbc0"
+  integrity sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
 
 node-emoji@1.11.0:
   version "1.11.0"
@@ -2363,6 +2429,13 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -2699,6 +2772,18 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+sinon@15.2.0:
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-15.2.0.tgz#5e44d4bc5a9b5d993871137fd3560bebfac27565"
+  integrity sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+    "@sinonjs/fake-timers" "^10.3.0"
+    "@sinonjs/samsam" "^8.0.0"
+    diff "^5.1.0"
+    nise "^5.1.4"
+    supports-color "^7.2.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -2912,7 +2997,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -2996,7 +3081,7 @@ tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
### SUMMARY:

The main change here expose a way to bypass eslint's normal behavior (throwing an when rule violations occur) via a new a new environment variable. Doing so allows us to rely instead on ratcheting to throw if counts have increase and unlocks a few use cases:
- Running eslint in CI where rule violations alone would otherwise cause the job to fail
- Running eslint as a commit hook against older files which already have violations that won't/can't be fixed right way

Additional changes:
- updated documentation to have the correct name for the temp file
- fixed a few cases where `console` was being called directly instead of the expected `logger`
- brought in `prettier` as a dependency as well as `sinon` for mocking in tests

### TESTING NOTES:
"The first principle is that you must not fool yourself, and you are the easiest person to fool."
- Fill in notes about your test approach -- discussion points:
  - [X] Unit tests
  - [X] Run locally against main org repo
